### PR TITLE
Shebang for bash

### DIFF
--- a/mavenix.nix
+++ b/mavenix.nix
@@ -37,6 +37,7 @@ let
     }
   '';
 in writeScriptBin "mvnix" (''
+  #! /bin/bash
   set -e
 
   usage() {


### PR DESCRIPTION
Other shells (like `zsh`) complain about `export -f` otherwise.