### PR TITLE
Pin nixpkgs to version with yq 2.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }: with pkgs;
+{ pkgs ? import ./nixpkgs.nix {} }: with pkgs;
 
 let
   name = "mvnix";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,11 @@
+let source =
+    rec {
+      owner = "NixOS";
+      repo = "nixpkgs-channels";
+      rev = "0a7e258012b60cbe530a756f09a4f2516786d370";
+      sha256 = "1qcnxkqkw7bffyc17mqifcwjfqwbvn0vs0xgxnjvh9w0ssl2s036";
+      name = "nixpkgs${rev}";
+    };
+    fetch = (import <nixpkgs> {}).fetchFromGitHub;
+in
+import (fetch (source))


### PR DESCRIPTION
I didn't know if I should do anything with `release.nix`

Closes #7 