### PR TITLE
Re-implement overrideAttrs for buildMaven

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
 
       # Override which maven package to build with
       #
-      #maven = maven.override { jdk = pkgs.oraclejdk10; };
+      #maven = maven.overrideAttrs (_: { jdk = pkgs.oraclejdk10; });
 
       # Override remote repository URLs and settings.xml
       #

--- a/mavenix.nix
+++ b/mavenix.nix
@@ -151,7 +151,11 @@ let
     ' > $dir/${submod.name}.metadata.xml
   '';
 
-  buildMaven = makeOverridable ({
+  overrideOverrideAttrs = f: attrs: (f attrs) // {
+    overrideAttrs = f_: overrideOverrideAttrs f (attrs // (f_ attrs));
+  };
+
+  buildMaven = overrideOverrideAttrs ({
     src,
     infoFile,
     deps        ? [],

--- a/mavenix.nix
+++ b/mavenix.nix
@@ -17,7 +17,7 @@ let
   inherit (pkgs) stdenv runCommand fetchurl makeWrapper maven writeText
     requireFile yq;
   inherit (pkgs.lib) concatLists concatStrings importJSON strings
-    makeOverridable optionalAttrs optionalString;
+    optionalAttrs optionalString;
 
   maven' = maven;
   settings' = writeText "settings.xml" ''

--- a/mvnix-update
+++ b/mvnix-update
@@ -58,7 +58,7 @@ mkdir -p "$tmp_repo"
 ns_() {
   local ns_wd="$1";shift
   HOME="/tmp/nowhere" nix-shell --show-trace --pure \
-    --run "cd \"$ns_wd\"; $*" -E "($expression).override { build = false; }";
+    --run "cd \"$ns_wd\"; $*" -E "($expression).overrideAttrs (_: { build = false; })";
 }
 
 echo >&2 "


### PR DESCRIPTION
Avoid using `makeOverridable` because of `callPackage` hiding the `override` attribute (as stated in #18.)