### PR TITLE
Add JDK from maven to make available in nix-shell

### DIFF
--- a/mavenix.nix
+++ b/mavenix.nix
@@ -171,7 +171,7 @@ let
       dummy-info = { name = "update"; deps = []; metas = []; };
 
       config = config' // {
-        buildInputs = buildInputs ++ [ maven' ];
+        buildInputs = buildInputs ++ [ maven' maven.jdk ];
       };
       info = if build then importJSON infoFile else dummy-info;
       remotes' = (optionalAttrs (info?remotes) info.remotes) // remotes;


### PR DESCRIPTION
This will also add `JAVA_HOME` to shell environment.

Related issue <https://github.com/icetan/mavenix/issues/20>