### PR TITLE
Build tests during buildPhase although they are not run

### DIFF
--- a/mavenix.nix
+++ b/mavenix.nix
@@ -227,7 +227,7 @@ let
           runHook preBuild
 
           $mvn --version
-          $mvn package -DskipTests=true -Dmaven.test.skip=true
+          $mvn package -DskipTests=true -Dmaven.test.skip.exec=true
 
           runHook postBuild
         '';


### PR DESCRIPTION
Projects may share unit tests by bundling them into "associated test
JARs". Setting `-Dmaven.test.skip` prevents even building the tests, so the
associated JARs are not built, and other projects complain of missing
dependencies. Instead set `-Dmaven.test.skip.exec` so that the unit tests are
compiled, but not run, during `buildPhase`.

Fixes: #32 