### PR TITLE
Check if `infoFile` exists before importing

### DIFF
--- a/mavenix.nix
+++ b/mavenix.nix
@@ -175,7 +175,7 @@ let
     let
       dummy-info = { name = "update"; deps = []; metas = []; };
 
-      info = if build then importJSON infoFile else dummy-info;
+      info = if (build && pathExists infoFile) then importJSON infoFile else dummy-info;
       remotes' = (optionalAttrs (info?remotes) info.remotes) // remotes;
       drvsInfo = transInfo drvs;
 


### PR DESCRIPTION
When `drvs` is set and `mvnix-update` is being run to generate the initial `infoFile`, then `drvsInfo` will be non-empty. Because `drvsInfo` is now non-empty, `transRemotes drvsInfo` (in `mkRepo`) will now be evaluated (when `drvsInfo` is empty, the `foldl'` is a no-op). `transRemotes` references `info.remotes`, and `info` is defined as importing the `infoFile` (which we're trying to generate!).

This PR fixes this by checking if the path to `infoFile` exists before attempting to import it.
