### PR TITLE
fetchGit -> fetchTarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ manually clone the target project repository.
 E.g. generate and build a Nix package for Traccar v4.2:
 
 ```sh
-mvnix-init -S 'fetchGit { url = git://github.com/traccar/traccar.git; ref = "v4.2"; }'
+mvnix-init -S 'fetchTarball "http://github.com/traccar/traccar/tarball/v4.2"'
 mvnix-update
 nix-build
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,5 @@
 {
-  pkgs ? (import (fetchGit {
-    url = "https://github.com/NixOS/nixpkgs-channels";
-    ref = "nixos-19.09";
-    rev = "c75de8bc12cc7e713206199e5ca30b224e295041";
-  }) {}),
+  pkgs ? (import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/tarball/c75de8bc12cc7e713206199e5ca30b224e295041";) {}),
   mavenixLib ? import ./mavenix.nix { inherit pkgs; },
 }: with pkgs;
 

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? (import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/tarball/c75de8bc12cc7e713206199e5ca30b224e295041";) {}),
+  pkgs ? (import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/tarball/c75de8bc12cc7e713206199e5ca30b224e295041") {}),
   mavenixLib ? import ./mavenix.nix { inherit pkgs; },
 }: with pkgs;
 


### PR DESCRIPTION
Replaced `fetchGit` with `fetchTarball` which works much faster, especially for big repositories like `nixpkgs` or `nixpkgs-channels`